### PR TITLE
Ensure something is echoed on failure

### DIFF
--- a/wait_for.sh
+++ b/wait_for.sh
@@ -129,7 +129,7 @@ get_workspace_state() {
     if [ "x${get_workspace_state}" = "xapplied" ]; then
 	echo ""
     else
-	echo "$get_workspace_state"
+	echo "$get_workspace_state not ready"
     fi
 }
 


### PR DESCRIPTION
If you echo an empty sting from these check fns the job/pod etc. is seen as completed/ready.