### PR TITLE
fix(service): wait for service if not yet defined in k8s

### DIFF
--- a/wait_for.sh
+++ b/wait_for.sh
@@ -111,13 +111,17 @@ get_pod_state() {
 # example output with 2 services each matching a single pod would be: "falsefalse"
 get_service_state() {
     get_service_state_name="$1"
-    get_service_state_selectors=$(kubectl get service "$get_service_state_name" $KUBECTL_ARGS -ojson 2>&1 | jq -cr 'if . | has("items") then .items[] else . end | [ .spec.selector | to_entries[] | "-l\(.key)=\(.value)" ] | join(",") ')
-    get_service_state_states=""
-    for get_service_state_selector in $get_service_state_selectors ; do
-        get_service_state_selector=$(echo "$get_service_state_selector" | tr ',' ' ')
-        get_service_state_state=$(get_pod_state "$get_service_state_selectors")
-        get_service_state_states="${get_service_state_states}${get_service_state_state}" ;
-    done
+    get_service_state_selectors=$(kubectl get service "$get_service_state_name" $KUBECTL_ARGS -ojson 2> /dev/null | jq -cr 'if . | has("items") then .items[] else . end | [ .spec.selector | to_entries[] | "-l\(.key)=\(.value)" ] | join(",") ')
+    if [ -z "$get_service_state_selectors" ]; then
+	get_service_state_states="service $get_service_state_name not found"
+    else
+	get_service_state_states=""
+	for get_service_state_selector in $get_service_state_selectors ; do
+            get_service_state_selector=$(echo "$get_service_state_selector" | tr ',' ' ')
+            get_service_state_state=$(get_pod_state "$get_service_state_selectors")
+            get_service_state_states="${get_service_state_states}${get_service_state_state}" ;
+	done
+    fi
     echo "$get_service_state_states"
 }
 


### PR DESCRIPTION
If the `service` is yet to be defined in k8s, the wait for check immediately succeeds. 